### PR TITLE
fix ivm v1.1 van vroegsignalering

### DIFF
--- a/docs/api/berichten.md
+++ b/docs/api/berichten.md
@@ -10,7 +10,7 @@ De technische beschrijving van de API is in het volgende OAS3-bestand beschreven
 ```
 </details>
 
-- [Klik hier om het bestand te downloaden](https://raw.githubusercontent.com/VNG-Realisatie/ddas-vroegsignalering/main/v1.0/DDAS-SHV.yaml)  
+- [Klik hier om het bestand te downloaden](https://raw.githubusercontent.com/VNG-Realisatie/ddas/main/v1.0/DDAS-SHV.yaml)  
 
 
 ## Vroegsignaleringsgegevens
@@ -23,7 +23,7 @@ De technische beschrijving van de API is in het volgende OAS3-bestand beschreven
 ```
 </details>
 
-- [Klik hier om het bestand te downloaden](https://raw.githubusercontent.com/VNG-Realisatie/ddas-vroegsignalering/refs/heads/main/v1.0/DDAS-VS.yaml)  
+- [Klik hier om het bestand te downloaden](https://raw.githubusercontent.com/VNG-Realisatie/ddas/main/v1.0/DDAS-VS.yaml)  
 
 
 Hieronder worden de berichten die in het OAS-bestand technisch beschreven zijn, toegelicht.
@@ -31,7 +31,7 @@ Hieronder worden de berichten die in het OAS-bestand technisch beschreven zijn, 
 
 ## Encoding
 
-Conform de specificaties voor de bestandsuitwisseling voor [schuldhulpverlening](https://vng-realisatie.github.io/ddas/v1.0/uitwisselspecificatie/) en [vroegsignalering](https://vng-realisatie.github.io/ddas-vroegsignalering/v1.0/uitwisselspecificatie/), is de encoding van de berichten UTF-8.
+Conform de specificaties voor de bestandsuitwisseling voor [schuldhulpverlening](https://vng-realisatie.github.io/ddas/v1.0/uitwisselspecificatie/) en [vroegsignalering](https://vng-realisatie.github.io/ddas-vroegsignalering/v1.1/uitwisselspecificatie/), is de encoding van de berichten UTF-8.
 
 
 ## Vraagbericht (request)

--- a/v1.0/DDAS-VS.yaml
+++ b/v1.0/DDAS-VS.yaml
@@ -80,7 +80,7 @@ components:
 
   schemas:
     Uitwisselmodel:
-      $ref: 'https://raw.githubusercontent.com/VNG-Realisatie/ddas-vroegsignalering/main/v1.0/json_schema_Uitwisselmodel.json'
+      $ref: 'https://raw.githubusercontent.com/VNG-Realisatie/ddas-vroegsignalering/main/v1.1/json_schema_Uitwisselmodel.json'
 
     Paginering:
       type: object


### PR DESCRIPTION
- OAS-yaml voor vroegsignalering > verwijzing naar uitwisselspecs v1.1 voor vroegsignalering
- Berichten.md > verwijzing naar v1.1 voor vroegsignalering (en fix zodat naar de OAS-yaml in de eigen repo verwezen wordt)