### PR TITLE
Update DDAS-VS.yaml ivm uitwisselmodel VS v1.2draft

### DIFF
--- a/v1.0/DDAS-SHV.yaml
+++ b/v1.0/DDAS-SHV.yaml
@@ -122,9 +122,9 @@ components:
           type: string
           format: date
           example: "2025-12-31"
-        aanleverende_organisatie:
+        aanleverendeOrganisatie:
           type: string
-          example: "Gemeente Voorbeeldstad"
+          example: "Naam Gegevensleverancier"
         page:
           type: integer
           minimum: 1

--- a/v1.0/DDAS-VS.yaml
+++ b/v1.0/DDAS-VS.yaml
@@ -80,7 +80,7 @@ components:
 
   schemas:
     Uitwisselmodel:
-      $ref: 'https://raw.githubusercontent.com/VNG-Realisatie/ddas-vroegsignalering/main/v1.1/json_schema_Uitwisselmodel.json'
+      $ref: 'https://raw.githubusercontent.com/VNG-Realisatie/ddas-vroegsignalering/main/v1.2draft/json_schema_Uitwisselmodel.json'
 
     Paginering:
       type: object
@@ -122,9 +122,9 @@ components:
           type: string
           format: date
           example: "2025-12-31"
-        aanleverende_organisatie:
+        aanleverendeOrganisatie:
           type: string
-          example: "Gemeente Voorbeeldstad"
+          example: "Naam Gegevensleverancier"
         page:
           type: integer
           minimum: 1

--- a/v1.0/DDAS-VS.yaml
+++ b/v1.0/DDAS-VS.yaml
@@ -80,7 +80,7 @@ components:
 
   schemas:
     Uitwisselmodel:
-      $ref: 'https://raw.githubusercontent.com/VNG-Realisatie/ddas-vroegsignalering/main/v1.2draft/json_schema_Uitwisselmodel.json'
+      $ref: 'https://raw.githubusercontent.com/VNG-Realisatie/ddas-vroegsignalering/main/v1.2-draft/json_schema_Uitwisselmodel.json'
 
     Paginering:
       type: object


### PR DESCRIPTION
Uitwisselmodel verwijst naar v1.2draft (was v1.1)
Direct meegenomen:
aanleverende_organisatie > aanleverendeOrganisatie
example: "Gemeente Voorbeeldstad" > "Naam Gegevensleverancier"