### PR TITLE
aanleverendeOrganisatie -> aanleverende_organisatie

### DIFF
--- a/docs/api/berichten.md
+++ b/docs/api/berichten.md
@@ -44,7 +44,7 @@ Parameters die meegestuurd kunnen worden (allemaal optioneel):
 
 - aanleverperiodeEinddatum (date - startdatum van rapportageperiode, default leeg: gegevensleverancier bepaalt dan einddatum<sup>*</sup>)
 
-- Aanleverende_organisatie (string - organisatie waarvan de gegevens geleverd worden, default alle; alleen relevant als over meer dan 1 organisatie (gemeente/ schuldhulpverlener) gegevens aangeleverd worden)
+- aanleverende_organisatie (string - organisatie waarvan de gegevens geleverd worden, default alle; alleen relevant als over meer dan 1 organisatie (gemeente/ schuldhulpverlener) gegevens aangeleverd worden)
 
 - page (integer - de gewenste pagina, als er meerdere pagina's aan gegevens zijn; zie ook [niet-functionele eisen](non-functionals.md#performance), default de eerste pagina)
 

--- a/v1.0/DDAS-SHV.yaml
+++ b/v1.0/DDAS-SHV.yaml
@@ -122,7 +122,7 @@ components:
           type: string
           format: date
           example: "2025-12-31"
-        aanleverendeOrganisatie:
+        aanleverende_organisatie:
           type: string
           example: "Naam Gegevensleverancier"
         page:


### PR DESCRIPTION
Te snel vervangen door aanleverendeOrganisatie - moet voor SHV pas bij nieuwe versie uitwisselformaat. Dus even teruggedraaid.